### PR TITLE
fix metadata typo on response modes supported

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -593,7 +593,7 @@ server supports. The server MUST support the <code>openid</code> scope value.<
 <li>  JSON array containing a list of the OAuth 2.0 response_type values that
 this DH supports.</li>
 </ul></li>
-<li>response_mode_supported
+<li>response_modes_supported
 
 <ul>
 <li>  REQUIRED</li>


### PR DESCRIPTION
a small PR to fix the `response_modes_supported` property of the oidc discovery document
https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata