### PR TITLE
fix typo on userinfo endpoint

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1013,7 +1013,7 @@ Content-Type: application/json
   "token_endpoint": "https://www.dh.com.au/token",
   "introspection_endpoint": "https://www.dh.com.au/introspect",
   "revocation_endpoint": "https://www.dh.com.au/revoke",
-  "user_info_endpoint": "https://www.dh.com.au/userinfo",
+  "userinfo_endpoint": "https://www.dh.com.au/userinfo",
   "jwks_uri": "https://www.dh.com.au/jwks",
   "registration_endpoint": "https://www.dh.com.au/register",
   "bc-authorize": "https://www.dh.com.au/bc-authorise",
@@ -1071,7 +1071,7 @@ OpenID Provider Configuration is directly impacted by the emerging requirements 
 <li><code>token_endpoint</code>: URL of the Token Endpoint.</li>
 <li><code>introspection_endpoint</code>: URL of the Introspection Endpoint.</li>
 <li><code>revocation_endpoint</code>: URL of the Revocation Endpoint.</li>
-<li><code>user_info_endpoint</code>: URL of the UserInfo Endpoint.</li>
+<li><code>userinfo_endpoint</code>: URL of the UserInfo Endpoint.</li>
 <li><code>jwks_uri</code>: URL of the JWKS Endpoint.</li>
 <li><code>scopes_supported</code>:  This list of supported scopes.</li>
 <li><code>claims_supported</code>:  The list of supported claims.</li>


### PR DESCRIPTION
another small pr to fix `userinfo_endpoint` typo on metadata endpoint
https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata